### PR TITLE
feat: 친구 신청글 수정

### DIFF
--- a/src/main/java/com/example/syncrowbackend/friend/controller/PostController.java
+++ b/src/main/java/com/example/syncrowbackend/friend/controller/PostController.java
@@ -1,9 +1,7 @@
 package com.example.syncrowbackend.friend.controller;
 
 import com.example.syncrowbackend.common.security.UserDetailsImpl;
-import com.example.syncrowbackend.friend.dto.FriendRequestPostDto;
-import com.example.syncrowbackend.friend.dto.PostRequestDto;
-import com.example.syncrowbackend.friend.dto.PostDto;
+import com.example.syncrowbackend.friend.dto.*;
 import com.example.syncrowbackend.friend.enums.FriendRequestStatus;
 import com.example.syncrowbackend.friend.service.PostService;
 import jakarta.validation.Valid;
@@ -36,13 +34,13 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
+    // 로그인한 사용자가 쓴 친구신청 post
+    // (status) 로그인한 사용자가 신청 넣은 친구신청 post 정보
     @GetMapping("/user/posts")
-    public ResponseEntity<Page<PostDto>> searchPostsByStatus(@RequestParam(required = false) FriendRequestStatus status, @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        if (status != null) {
-            return ResponseEntity.ok(postService.searchByStatus(status, pageable));
-        } else {
-            return ResponseEntity.ok(postService.searchAllPost(pageable));
-        }
+    public ResponseEntity<Page<GetUserResponseDto>> getPostByCurrentUser(@RequestParam(required = false) FriendRequestStatus status, @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return status==null ?
+                ResponseEntity.ok(postService.getFriendRequestsByCurrentUser(userDetails.getUser(), pageable)) :
+                ResponseEntity.ok(postService.getReceivedFriendRequestsByCurrentUser(userDetails.getUser(), status, pageable));
     }
 
     @GetMapping("/list/user/{kakaoId}")

--- a/src/main/java/com/example/syncrowbackend/friend/dto/GetUserResponseDto.java
+++ b/src/main/java/com/example/syncrowbackend/friend/dto/GetUserResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.syncrowbackend.friend.dto;
+
+import com.example.syncrowbackend.friend.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GetUserResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private WriterDto writer;
+
+    @Builder
+    public static GetUserResponseDto toDto(Post post) {
+        return GetUserResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .writer(WriterDto.toDto(post.getUser())).build();
+    }
+}

--- a/src/main/java/com/example/syncrowbackend/friend/dto/PostDto.java
+++ b/src/main/java/com/example/syncrowbackend/friend/dto/PostDto.java
@@ -44,18 +44,4 @@ public class PostDto {
                 .modifiedAt(post.getModifiedAt())
                 .build();
     }
-
-    @Builder
-    public static PostDto toDtoRej(Post post, List<Integer> rejectedUsers){
-        return PostDto.builder()
-                .id(post.getId())
-                .username(post.getUser().getUsername())
-                .profileImage(post.getUser().getProfileImage())
-                .temp(post.getUser().getTemp())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .rejectedUsers(rejectedUsers)
-                .modifiedAt(post.getModifiedAt())
-                .build();
-    }
 }

--- a/src/main/java/com/example/syncrowbackend/friend/dto/WriterDto.java
+++ b/src/main/java/com/example/syncrowbackend/friend/dto/WriterDto.java
@@ -1,0 +1,30 @@
+package com.example.syncrowbackend.friend.dto;
+
+import com.example.syncrowbackend.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class WriterDto{
+    private Long id;
+    private String username;
+    private String profileImage;
+    private Double temp;
+
+    @Builder
+    public static WriterDto toDto(User user) {
+        if(user == null)
+            return null;
+
+        return WriterDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .profileImage(user.getProfileImage())
+                .temp(user.getTemp()).build();
+    }
+}

--- a/src/main/java/com/example/syncrowbackend/friend/entity/FriendRequest.java
+++ b/src/main/java/com/example/syncrowbackend/friend/entity/FriendRequest.java
@@ -19,13 +19,13 @@ public class FriendRequest extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "request_user_id", referencedColumnName = "id")
-    private User requestUserId;
+    @JoinColumn(name = "request_user_id")
+    private User requestUser;
 
     @ManyToOne
+    @JoinColumn(name = "post_id")
     private Post post;
 
     @Enumerated(EnumType.STRING)
     private FriendRequestStatus status;
-
 }

--- a/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
@@ -2,12 +2,11 @@ package com.example.syncrowbackend.friend.repository;
 
 import com.example.syncrowbackend.friend.entity.FriendRequest;
 import com.example.syncrowbackend.friend.enums.FriendRequestStatus;
+import com.example.syncrowbackend.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
-    Page<FriendRequest> findByStatus(FriendRequestStatus status, Pageable pageable);
-    // Page<FriendRequest> findByRequestUserIdAndStatus(Long userId, FriendRequestStatus status, Pageable pageable);
-
+    Page<FriendRequest> findByRequestUserAndStatus(User requestUser, FriendRequestStatus status, Pageable pageable);
 }

--- a/src/main/java/com/example/syncrowbackend/friend/service/PostService.java
+++ b/src/main/java/com/example/syncrowbackend/friend/service/PostService.java
@@ -1,8 +1,6 @@
 package com.example.syncrowbackend.friend.service;
 
-import com.example.syncrowbackend.friend.dto.FriendRequestPostDto;
-import com.example.syncrowbackend.friend.dto.PostRequestDto;
-import com.example.syncrowbackend.friend.dto.PostDto;
+import com.example.syncrowbackend.friend.dto.*;
 import com.example.syncrowbackend.friend.enums.FriendRequestStatus;
 import com.example.syncrowbackend.user.entity.User;
 import org.springframework.data.domain.Page;
@@ -12,8 +10,8 @@ import org.springframework.data.domain.Pageable;
 public interface PostService {
     Long createPost(User user, PostRequestDto postDto);
     void deletePost(User user, Long postId);
-    Page<PostDto> searchAllPost(Pageable pageable);
-    Page<PostDto> searchByStatus(FriendRequestStatus status, Pageable pageable);
+    Page<GetUserResponseDto> getFriendRequestsByCurrentUser(User user, Pageable pageable);
+    Page<GetUserResponseDto> getReceivedFriendRequestsByCurrentUser(User user, FriendRequestStatus status, Pageable pageable);
     Page<FriendRequestPostDto> searchPostsByUser(String kakaoId, Pageable pageable);
 
 }


### PR DESCRIPTION
## Issue #12 

## 요약
* 아래의 명세대로 CRUD 작성
* Dto를 Request/Response로 각각 분할
* 조인 테이블의 정보를 가져오기 위해 엔티티를 거쳐 데이터를 조회하는 방법으로 구현


## 구현된 API
#### /api/posts
- 신청 글 작성[ createPost ] 
- (Request) title, content, groupId

#### /api/posts/{postId}
- 신청 글 삭제[ deletePost ]
- (Request) postId

#### /api/user/posts
- 신청 글 조회[ searchPost ]
- (Response) id, title, content, writer(id, username, profileImage, temp)
- 로그인한 사용자가 쓴 친구신청 post

#### /api/user/posts?status = ACCEPTED
- 신청 완료 조회[ searchByStatus ]
- (Response) 아이디, title, content, username, profileImage, temp
- 로그인한 사용자가 신청 넣은 친구신청 post 정보 중 같은 status 필터링

Postman으로 해당 기능에 대해 테스트 완료했습니다!