### PR TITLE
Feature/그룹 기능 구현

### DIFF
--- a/src/main/java/com/example/syncrowbackend/friend/controller/GroupController.java
+++ b/src/main/java/com/example/syncrowbackend/friend/controller/GroupController.java
@@ -1,11 +1,18 @@
 package com.example.syncrowbackend.friend.controller;
 
-import com.example.syncrowbackend.friend.dto.GroupResponseDto;
+import com.example.syncrowbackend.common.security.UserDetailsImpl;
+import com.example.syncrowbackend.friend.dto.GetGroupPostsResponseDto;
+import com.example.syncrowbackend.friend.dto.GetGroupsResponseDto;
 import com.example.syncrowbackend.friend.enums.GroupCategory;
 import com.example.syncrowbackend.friend.service.GroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,27 +23,23 @@ public class GroupController {
     @Autowired
     private final GroupService groupService;
 
-//    // 그룹 입장
-//    @PostMapping("/groups/{groupId}/enter")
-//    public ResponseEntity<Void> enterGroup(@PathVariable Long groupId){
-//        return ResponseEntity.ok(groupService.enterGroup(groupId));
-//    }
-//
-//    // 그룹 전체 조회
-//    @GetMapping("/groups")
-//    public ResponseEntity<GroupResponseDto> searchAllGroup(@RequestParam GroupCategory category) {
-//        return ResponseEntity.ok(groupService.searchAllGroup()).build();
-//    }
-//
-//    // 그룹 탐색
-//    @GetMapping("/groups/{groupId}/posts")
-//    public ResponseEntity<GroupResponseDto> searchGroupById(@PathVariable Long groupId, @RequestParam Long page, @RequestParam Long limit, @RequestParam Long offset) {
-//        return ResponseEntity.ok().build();
-//    }
+    @PostMapping("/groups/{groupId}/enter")
+    public ResponseEntity<Long> groupEnter(@PathVariable Long groupId, @AuthenticationPrincipal UserDetailsImpl userDetails){
+        return ResponseEntity.ok(groupService.groupEnter(groupId, userDetails.getUser()));
+    }
 
-//    // 참여중인 그룹 조회
-//    @GetMapping("/user/groups")
-//    public ResponseEntity<GroupResponseDto> searchJoinedGroups(@PathVariable Long id) {
-//        return ResponseEntity.ok().build();
-//    }
+    @GetMapping("/groups")
+    public ResponseEntity<Page<GetGroupsResponseDto>> getGroupsByCategory(@RequestParam GroupCategory category, Pageable pageable) {
+        return ResponseEntity.ok(groupService.getGroupsByCategory(category, pageable));
+    }
+
+    @GetMapping("/groups/{groupId}/posts")
+    public ResponseEntity<Page<GetGroupPostsResponseDto>> getGroupsByDesiredSize(@PathVariable Long groupId, @RequestParam Integer page, @RequestParam Integer limit, Pageable pageable) {
+        return ResponseEntity.ok(groupService.getGroupsByDesiredSize(groupId, page, limit, pageable));
+    }
+
+    @GetMapping("/user/groups")
+    public ResponseEntity<Page<GetGroupsResponseDto>> getParticipatingGroups(@AuthenticationPrincipal UserDetailsImpl userDetails, @PageableDefault(sort = "id",  direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(groupService.getParticipatingGroups(userDetails.getUser(), pageable));
+    }
 }

--- a/src/main/java/com/example/syncrowbackend/friend/dto/GetGroupPostsResponseDto.java
+++ b/src/main/java/com/example/syncrowbackend/friend/dto/GetGroupPostsResponseDto.java
@@ -1,0 +1,34 @@
+package com.example.syncrowbackend.friend.dto;
+
+import com.example.syncrowbackend.friend.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GetGroupPostsResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private WriterDto writerDto;
+    private List<Long> rejectedUsers = new ArrayList<>();
+
+    @Builder
+    public static GetGroupPostsResponseDto toDto(Post post, List<Long> rejectedUsers) {
+        return GetGroupPostsResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .writerDto(WriterDto.toDto(post.getUser()))
+                .rejectedUsers(rejectedUsers)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/syncrowbackend/friend/dto/GetGroupsResponseDto.java
+++ b/src/main/java/com/example/syncrowbackend/friend/dto/GetGroupsResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.syncrowbackend.friend.dto;
+
+import com.example.syncrowbackend.friend.entity.Group;
+import com.example.syncrowbackend.friend.enums.GroupCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GetGroupsResponseDto {
+    private Long id;
+    private String name;
+    private GroupCategory category;
+    private Integer memberCount;
+    private Integer postCount;
+
+    @Builder
+    public static GetGroupsResponseDto toDto(Group group) {
+        return GetGroupsResponseDto.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .category(group.getCategory())
+                .memberCount(group.getUserGroups().size())
+                .postCount(group.getPosts().size())
+                .build();
+    }
+}

--- a/src/main/java/com/example/syncrowbackend/friend/entity/Group.java
+++ b/src/main/java/com/example/syncrowbackend/friend/entity/Group.java
@@ -12,18 +12,22 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "group_info")
+@Table(name = "`group`")
 public class Group {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
-    private List<UserGroup> userGroups;
 
     @NotBlank
     private String name;
 
     @Enumerated(EnumType.STRING)
     private GroupCategory category;
+
+    @OneToMany(mappedBy = "`group`")
+    private List<Post> posts;
+
+    @OneToMany(mappedBy = "`group`")
+    private List<UserGroup> userGroups;
 }
+

--- a/src/main/java/com/example/syncrowbackend/friend/entity/Group.java
+++ b/src/main/java/com/example/syncrowbackend/friend/entity/Group.java
@@ -12,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "`group`")
+@Table(name = "group")
 public class Group {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,10 +24,10 @@ public class Group {
     @Enumerated(EnumType.STRING)
     private GroupCategory category;
 
-    @OneToMany(mappedBy = "`group`")
+    @OneToMany(mappedBy = "group")
     private List<Post> posts;
 
-    @OneToMany(mappedBy = "`group`")
+    @OneToMany(mappedBy = "group")
     private List<UserGroup> userGroups;
 }
 

--- a/src/main/java/com/example/syncrowbackend/friend/entity/Group.java
+++ b/src/main/java/com/example/syncrowbackend/friend/entity/Group.java
@@ -12,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "group")
+@Table(name = "`group`")
 public class Group {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
@@ -9,9 +9,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
-    Page<FriendRequest> findByStatus(FriendRequestStatus status, Pageable pageable);
-    // Page<FriendRequest> findByRequestUserIdAndStatus(Long userId, FriendRequestStatus status, Pageable pageable);
+    Page<FriendRequest> findByPostId(Long postId);
     boolean existsByRequestUserAndPost(User requestUser, Post post);
-
     Page<FriendRequest> findByRequestUserAndStatus(User requestUser, FriendRequestStatus status, Pageable pageable);
+
 }

--- a/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
-    Page<FriendRequest> findByPostId(Long postId);
+    Page<FriendRequest> findByPostId(Long postId, Pageable pageable);
     boolean existsByRequestUserAndPost(User requestUser, Post post);
     Page<FriendRequest> findByRequestUserAndStatus(User requestUser, FriendRequestStatus status, Pageable pageable);
 

--- a/src/main/java/com/example/syncrowbackend/friend/repository/GroupRepository.java
+++ b/src/main/java/com/example/syncrowbackend/friend/repository/GroupRepository.java
@@ -11,5 +11,4 @@ import java.util.Optional;
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Page<Group> findByCategory(GroupCategory category, Pageable pageable);
     Optional<Group> findById(Long id);
-
 }

--- a/src/main/java/com/example/syncrowbackend/friend/repository/PostRepository.java
+++ b/src/main/java/com/example/syncrowbackend/friend/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.example.syncrowbackend.friend.repository;
 
+import com.example.syncrowbackend.friend.entity.Group;
 import com.example.syncrowbackend.friend.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,5 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAll(Pageable pageable);
     Page<Post> findByUserId(Long id, Pageable pageable);
+    Page<Post> findByGroup(Group group, Pageable pageable);
 
 }

--- a/src/main/java/com/example/syncrowbackend/friend/repository/UserGroupRepository.java
+++ b/src/main/java/com/example/syncrowbackend/friend/repository/UserGroupRepository.java
@@ -1,0 +1,9 @@
+package com.example.syncrowbackend.friend.repository;
+
+import com.example.syncrowbackend.friend.entity.UserGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
+}

--- a/src/main/java/com/example/syncrowbackend/friend/service/GroupService.java
+++ b/src/main/java/com/example/syncrowbackend/friend/service/GroupService.java
@@ -1,4 +1,16 @@
 package com.example.syncrowbackend.friend.service;
 
+import com.example.syncrowbackend.friend.dto.*;
+import com.example.syncrowbackend.friend.enums.GroupCategory;
+import com.example.syncrowbackend.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface GroupService {
+
+    Long groupEnter(Long groupId, User user);
+    Page<GetGroupsResponseDto> getGroupsByCategory(GroupCategory category, Pageable pageable);
+    Page<GetGroupPostsResponseDto> getGroupsByDesiredSize(Long groupId, Integer page, Integer limit, Pageable pageable);
+    Page<GetGroupsResponseDto> getParticipatingGroups(User user, Pageable pageable);
+
 }

--- a/src/main/java/com/example/syncrowbackend/friend/service/GroupServiceImpl.java
+++ b/src/main/java/com/example/syncrowbackend/friend/service/GroupServiceImpl.java
@@ -1,9 +1,122 @@
 package com.example.syncrowbackend.friend.service;
 
+import com.example.syncrowbackend.common.exception.CustomException;
+import com.example.syncrowbackend.common.exception.ErrorCode;
+import com.example.syncrowbackend.friend.dto.GetGroupPostsResponseDto;
+import com.example.syncrowbackend.friend.dto.GetGroupsResponseDto;
+import com.example.syncrowbackend.friend.entity.FriendRequest;
+import com.example.syncrowbackend.friend.entity.Group;
+import com.example.syncrowbackend.friend.entity.Post;
+import com.example.syncrowbackend.friend.entity.UserGroup;
+import com.example.syncrowbackend.friend.enums.FriendRequestStatus;
+import com.example.syncrowbackend.friend.enums.GroupCategory;
+import com.example.syncrowbackend.friend.repository.FriendRequestRepository;
+import com.example.syncrowbackend.friend.repository.GroupRepository;
+import com.example.syncrowbackend.friend.repository.PostRepository;
+import com.example.syncrowbackend.friend.repository.UserGroupRepository;
+import com.example.syncrowbackend.user.entity.User;
+import com.example.syncrowbackend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class GroupServiceImpl implements GroupService{
+
+    private final Logger LOGGER = LoggerFactory.getLogger(GroupServiceImpl.class);
+
+    private final PostRepository postRepository;
+    private final GroupRepository groupRepository;
+    private final UserGroupRepository userGroupRepository;
+    private final FriendRequestRepository friendRequestRepository;
+
+    @Override
+    public Long groupEnter(Long groupId, User user) {
+        LOGGER.info("groupEnter service 호출됨");
+        Group group = findGroup(groupId);
+
+        UserGroup userGroup = UserGroup.builder()
+                .user(user)
+                .group(group)
+                .build();
+
+        userGroupRepository.save(userGroup);
+        return userGroup.getId();
+    }
+
+    @Override
+    public Page<GetGroupsResponseDto> getGroupsByCategory(GroupCategory category, Pageable pageable) {
+        LOGGER.info("getGroupsByCategory service 호출됨");
+        Page<Group> groups = groupRepository.findByCategory(category, pageable);
+        return groups.map(GetGroupsResponseDto::toDto);
+    }
+
+    @Override
+    public Page<GetGroupPostsResponseDto> getGroupsByDesiredSize(Long groupId, Integer page, Integer limit, Pageable pageable) {
+        LOGGER.info("getGroupsByDesiredSize service 호출됨");
+        Optional<Group> optionalGroup = groupRepository.findById(groupId);
+        if(optionalGroup.isEmpty()){
+            throw new CustomException(ErrorCode.GROUP_NOT_FOUND_ERROR, "해당 그룹을 찾을 수 없습니다.");
+        }
+
+        Page<Post> posts = postRepository.findByGroup(optionalGroup.get(), pageable);
+
+        List<GetGroupPostsResponseDto> responseDtoList = new ArrayList<>();
+        for (Post post : posts) {
+            User user = post.getUser();
+            if (user == null) {
+                throw new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "해당 작성자를 찾을 수 없습니다.");
+            }
+
+            Page<FriendRequest> friendRequests = friendRequestRepository.findByPostId(post.getId());
+            List<Long> rejectedUsers = new ArrayList<>();
+
+            for (FriendRequest friendRequest : friendRequests) {
+                if (friendRequest.getStatus() == FriendRequestStatus.REFUSED) {
+                    rejectedUsers.add(friendRequest.getRequestUser().getId());
+                }
+            }
+            responseDtoList.add(GetGroupPostsResponseDto.toDto(post, rejectedUsers));
+        }
+        return new PageImpl<>(responseDtoList, PageRequest.of(page, limit), posts.getTotalElements());
+    }
+
+    @Override
+    public Page<GetGroupsResponseDto> getParticipatingGroups(User user, Pageable pageable) {
+        LOGGER.info("getParticipatingGroups service 호출됨");
+        Page<FriendRequest> friendRequests = friendRequestRepository.findByRequestUserAndStatus(user, FriendRequestStatus.ACCEPTED, pageable);
+
+        List<GetGroupsResponseDto> getGroupsResponseDtos = friendRequests.getContent().stream()
+                .map(friendRequest -> {
+                    Post post = friendRequest.getPost();
+                    if (post == null) {
+                        throw new CustomException(ErrorCode.POST_NOT_FOUND_ERROR, "해당 게시글을 찾을 수 없습니다.");
+                    }
+                    Group group = post.getGroup();
+                    if (group == null) {
+                        throw new CustomException(ErrorCode.GROUP_NOT_FOUND_ERROR, "해당 그룹을 찾을 수 없습니다.");
+                    }
+                    return GetGroupsResponseDto.toDto(group);
+                }).collect(Collectors.toList());
+
+        return new PageImpl<>(getGroupsResponseDtos, pageable, friendRequests.getTotalElements());
+    }
+
+
+    @Transactional(readOnly = true)
+    private Group findGroup(Long groupId) {
+        return groupRepository.findById(groupId).orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND_ERROR, "존재하지 않는 그룹입니다."));
+    }
 }

--- a/src/main/java/com/example/syncrowbackend/friend/service/GroupServiceImpl.java
+++ b/src/main/java/com/example/syncrowbackend/friend/service/GroupServiceImpl.java
@@ -15,7 +15,6 @@ import com.example.syncrowbackend.friend.repository.GroupRepository;
 import com.example.syncrowbackend.friend.repository.PostRepository;
 import com.example.syncrowbackend.friend.repository.UserGroupRepository;
 import com.example.syncrowbackend.user.entity.User;
-import com.example.syncrowbackend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +79,7 @@ public class GroupServiceImpl implements GroupService{
                 throw new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "해당 작성자를 찾을 수 없습니다.");
             }
 
-            Page<FriendRequest> friendRequests = friendRequestRepository.findByPostId(post.getId());
+            Page<FriendRequest> friendRequests = friendRequestRepository.findByPostId(post.getId(), pageable);
             List<Long> rejectedUsers = new ArrayList<>();
 
             for (FriendRequest friendRequest : friendRequests) {

--- a/src/main/java/com/example/syncrowbackend/friend/service/PostServiceImpl.java
+++ b/src/main/java/com/example/syncrowbackend/friend/service/PostServiceImpl.java
@@ -39,6 +39,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public Long createPost(User user, PostRequestDto postDto) {
         LOGGER.info("createPost service 호출됨");
+        // groupId가 현재 로그인한 user가 참여중인 그룹인지 검증
         Group group = findGroup(postDto.getGroupId());
 
         Post post = Post.builder()


### PR DESCRIPTION
## Issue #14 

## 요약
* 아래의 명세대로 CRUD 작성
* 그룹탐색에서 page, limit만으로 페이지네이션 진행
* 디비 직접 조회보다 엔티티 변수로 접근하고자 했음

## 구현된 API
### /api/groups/{groupId}/enter
- 그룹 입장 [ groupEnter ]
- DB user_group에 추가

### /api/groups?category=PPT
- 그룹 전체 조회 [ getGroupsByCategory ]
- (Response) id, name, category, memberCount, postCount
- 입력 category에 해당하는 그룹 정보 return

### /api/groups/{groupId}/posts?page=1&limit=10
- 그룹 탐색 [ getGroupsByDesiredSize ]
- (Response) id, title, content, writer(id, username, profileImage, temp), rejectedUsers
- groupId의 그룹에 속한 post와 작성자의 정보를 page, limit에 맞춰 return

### /api/user/groups
- 참여중인 그룹 조회 [ getParticipatingGroups ]
- (Response) id, name, category, memberCount, postCount
- 로그인한 사용자가 참여중(ACCEPTED)인 그룹 조회

Group관련 요구사항에 맞춰 구현 완료했습니다. 
여러 상황에서 테스트를 거치며 오류나는 부분이 없도록 최대한 수정해보겠습니다! 😎