### PR TITLE
feat: 신청글, 신청완료 조회 수정

### DIFF
--- a/src/main/java/com/example/syncrowbackend/friend/controller/GroupController.java
+++ b/src/main/java/com/example/syncrowbackend/friend/controller/GroupController.java
@@ -43,7 +43,7 @@ public class GroupController {
             @PathVariable Long groupId,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return ResponseEntity.ok(groupService.getGroupPostsByDesiredSize(groupId, pageable));
+        return ResponseEntity.ok(groupService.getAvailableGroupPosts(groupId, pageable));
     }
 
     @GetMapping("/user/groups")

--- a/src/main/java/com/example/syncrowbackend/friend/controller/PostController.java
+++ b/src/main/java/com/example/syncrowbackend/friend/controller/PostController.java
@@ -2,7 +2,6 @@ package com.example.syncrowbackend.friend.controller;
 
 import com.example.syncrowbackend.auth.security.UserDetailsImpl;
 import com.example.syncrowbackend.friend.dto.*;
-import com.example.syncrowbackend.friend.enums.FriendRequestStatus;
 import com.example.syncrowbackend.friend.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,17 +31,24 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
-    // 로그인한 사용자가 쓴 친구신청 post
-    // (status) 로그인한 사용자가 신청 넣은 친구신청 post 정보
     @GetMapping("/user/posts")
-    public ResponseEntity<Page<GetUserResponseDto>> getPostByCurrentUser(@RequestParam(required = false) FriendRequestStatus status, @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return status==null ?
-                ResponseEntity.ok(postService.getFriendRequestsByCurrentUser(userDetails.getUser(), pageable)) :
-                ResponseEntity.ok(postService.getReceivedFriendRequestsByCurrentUser(userDetails.getUser(), status, pageable));
+    public ResponseEntity<Page<GetUserResponseDto>> getPostsWrittenByCurrentUser(
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return ResponseEntity.ok(postService.getPostsWrittenByCurrentUser(userDetails.getUser(), pageable));
+    }
+
+    @GetMapping("/user/requests")
+    public ResponseEntity<Page<GetUserResponseDto>> getPostsRequestedByCurrentUser(
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return ResponseEntity.ok(postService.getPostsRequestedByCurrentUser(userDetails.getUser(), pageable));
     }
 
     @GetMapping("/list/user/{kakaoId}")
-    public ResponseEntity<Page<FriendRequestPostDto>> searchPostsByUser(@PathVariable String kakaoId, @PageableDefault(sort = "id",  direction = Sort.Direction.DESC) Pageable pageable) {
+    public ResponseEntity<Page<FriendRequestPostDto>> searchPostsByUser(@PathVariable String kakaoId, @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(postService.searchPostsByUser(kakaoId, pageable));
     }
 }

--- a/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
@@ -1,19 +1,20 @@
 package com.example.syncrowbackend.friend.repository;
 
+import com.example.syncrowbackend.auth.entity.User;
 import com.example.syncrowbackend.friend.entity.FriendRequest;
 import com.example.syncrowbackend.friend.entity.Post;
 import com.example.syncrowbackend.friend.enums.FriendRequestStatus;
-import com.example.syncrowbackend.auth.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
-    Page<FriendRequest> findByPostId(Long postId, Pageable pageable);
     boolean existsByRequestUserAndPost(User requestUser, Post post);
     Page<FriendRequest> findByRequestUserAndStatus(User requestUser, FriendRequestStatus status, Pageable pageable);
-
     List<FriendRequest> findByPostAndStatus(Post post, FriendRequestStatus friendRequestStatus);
+    boolean existsByPostAndStatusIn(Post post, List<FriendRequestStatus> statuses);
 }

--- a/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/example/syncrowbackend/friend/repository/FriendRequestRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Repository
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
     boolean existsByRequestUserAndPost(User requestUser, Post post);
-    Page<FriendRequest> findByRequestUserAndStatus(User requestUser, FriendRequestStatus status, Pageable pageable);
     List<FriendRequest> findByPostAndStatus(Post post, FriendRequestStatus friendRequestStatus);
     boolean existsByPostAndStatusIn(Post post, List<FriendRequestStatus> statuses);
+    Page<FriendRequest> findByRequestUserAndStatusIn(User user, List<FriendRequestStatus> includedStatuses, Pageable pageable);
 }

--- a/src/main/java/com/example/syncrowbackend/friend/repository/GroupRepository.java
+++ b/src/main/java/com/example/syncrowbackend/friend/repository/GroupRepository.java
@@ -2,13 +2,12 @@ package com.example.syncrowbackend.friend.repository;
 
 import com.example.syncrowbackend.friend.entity.Group;
 import com.example.syncrowbackend.friend.enums.GroupCategory;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
+@Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
     List<Group> findByCategory(GroupCategory category);
-    Optional<Group> findById(Long id);
 }

--- a/src/main/java/com/example/syncrowbackend/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/example/syncrowbackend/friend/service/FriendServiceImpl.java
@@ -29,11 +29,15 @@ public class FriendServiceImpl implements FriendService {
     @Override
     @Transactional
     public void friendRequest(FriendRequestDto requestDto, User user) {
+        Post post = findPost(requestDto.getPostId());
+
         if (!requestDto.getUserId().equals(user.getId())) {
             throw new CustomException(ErrorCode.PERMISSION_NOT_GRANTED_ERROR, "로그인한 사용자와 일치하지 않는 user id 입니다.");
         }
 
-        Post post = findPost(requestDto.getPostId());
+        if (post.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.PERMISSION_NOT_GRANTED_ERROR, "자기 자신에게 친구 신청할 수 없습니다.");
+        }
 
         if (friendRequestRepository.existsByRequestUserAndPost(user, post)) {
             throw new CustomException(ErrorCode.DUPLICATED_FRIEND_REQUEST, "친구 요청은 중복 불가합니다.");

--- a/src/main/java/com/example/syncrowbackend/friend/service/GroupService.java
+++ b/src/main/java/com/example/syncrowbackend/friend/service/GroupService.java
@@ -12,6 +12,6 @@ public interface GroupService {
     Long groupEnter(Long groupId, User user);
     List<GetGroupsResponseDto> getGroupsByCategory(GroupCategory category);
     GetGroupsResponseDto getGroups(Long groupId);
-    Page<GetGroupPostsResponseDto> getGroupPostsByDesiredSize(Long groupId, Pageable pageable);
+    Page<GetGroupPostsResponseDto> getAvailableGroupPosts(Long groupId, Pageable pageable);
     List<GetGroupsResponseDto> getParticipatingGroups(User user);
 }

--- a/src/main/java/com/example/syncrowbackend/friend/service/PostService.java
+++ b/src/main/java/com/example/syncrowbackend/friend/service/PostService.java
@@ -1,17 +1,14 @@
 package com.example.syncrowbackend.friend.service;
 
 import com.example.syncrowbackend.friend.dto.*;
-import com.example.syncrowbackend.friend.enums.FriendRequestStatus;
 import com.example.syncrowbackend.auth.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-
 public interface PostService {
     Long createPost(User user, PostRequestDto postDto);
     void deletePost(User user, Long postId);
-    Page<GetUserResponseDto> getFriendRequestsByCurrentUser(User user, Pageable pageable);
-    Page<GetUserResponseDto> getReceivedFriendRequestsByCurrentUser(User user, FriendRequestStatus status, Pageable pageable);
+    Page<GetUserResponseDto> getPostsWrittenByCurrentUser(User user, Pageable pageable);
+    Page<GetUserResponseDto> getPostsRequestedByCurrentUser(User user, Pageable pageable);
     Page<FriendRequestPostDto> searchPostsByUser(String kakaoId, Pageable pageable);
-
 }

--- a/src/main/java/com/example/syncrowbackend/friend/service/PostServiceImpl.java
+++ b/src/main/java/com/example/syncrowbackend/friend/service/PostServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.syncrowbackend.friend.service;
 
+import com.example.syncrowbackend.auth.entity.User;
+import com.example.syncrowbackend.auth.repository.UserRepository;
 import com.example.syncrowbackend.common.exception.CustomException;
 import com.example.syncrowbackend.common.exception.ErrorCode;
 import com.example.syncrowbackend.friend.dto.FriendRequestPostDto;
@@ -13,8 +15,6 @@ import com.example.syncrowbackend.friend.repository.FriendRequestRepository;
 import com.example.syncrowbackend.friend.repository.GroupRepository;
 import com.example.syncrowbackend.friend.repository.PostRepository;
 import com.example.syncrowbackend.friend.repository.UserGroupRepository;
-import com.example.syncrowbackend.auth.entity.User;
-import com.example.syncrowbackend.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -23,8 +23,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -40,7 +40,6 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional
     public Long createPost(User user, PostRequestDto postDto) {
-        // groupId가 현재 로그인한 user가 참여중인 그룹인지 검증
         Group group = findGroup(postDto.getGroupId());
         if (!userGroupRepository.existsByUserAndGroup(user, group)) {
             throw new CustomException(ErrorCode.PERMISSION_NOT_GRANTED_ERROR, "사용자가 참여중인 그룹이 아닙니다.");
@@ -70,26 +69,22 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<GetUserResponseDto> getFriendRequestsByCurrentUser(User user, Pageable pageable) {
-        /* 로그인한 사용자가 쓴 친구신청 post */
+    public Page<GetUserResponseDto> getPostsWrittenByCurrentUser(User user, Pageable pageable) {
         Page<Post> posts = postRepository.findByUserId(user.getId(), pageable);
         return posts.map(GetUserResponseDto::toDto);
     }
 
     @Override
     @Transactional
-    public Page<GetUserResponseDto> getReceivedFriendRequestsByCurrentUser(User user, FriendRequestStatus status, Pageable pageable) {
-        /* 로그인한 사용자가 신청넣은 친구신청 post 정보 */
-        Page<FriendRequest> friendRequests = friendRequestRepository.findByRequestUserAndStatus(user, status, pageable);
+    public Page<GetUserResponseDto> getPostsRequestedByCurrentUser(User user, Pageable pageable) {
+        List<FriendRequestStatus> includedStatuses = Arrays.asList(FriendRequestStatus.ACCEPTED, FriendRequestStatus.PROGRESS);
+        Page<FriendRequest> friendRequests = friendRequestRepository.findByRequestUserAndStatusIn(user, includedStatuses, pageable);
 
-        List<GetUserResponseDto> getUserResponseDtos = friendRequests.getContent().stream()
-                .map(friendRequest -> {
-                    Post post = friendRequest.getPost();
-                    if (post == null) {
-                        throw new CustomException(ErrorCode.POST_NOT_FOUND_ERROR, "해당 게시글을 찾을 수 없습니다.");
-                    }
-                    return GetUserResponseDto.toDto(post);
-                }).collect(Collectors.toList());
+        List<GetUserResponseDto> getUserResponseDtos = friendRequests.getContent()
+                .stream()
+                .map(FriendRequest::getPost)
+                .map(GetUserResponseDto::toDto)
+                .toList();
 
         return new PageImpl<>(getUserResponseDtos, pageable, friendRequests.getTotalElements());
     }


### PR DESCRIPTION
## Issue #21 
## 변경 사항
1.  그룹 탐색 
**GET /api/groups/{groupId}/posts**
`getAvailableGroupPosts` 메서드에서 그룹에 속한 게시물을 페이지네이션하여 반환합니다.
이때 `ACCEPTED`나 `PROGRESS` 상태의 친구 신청이 존재하지 않는 게시물만 남겨두고 필터링하도록 수정하였습니다.

2. 마이페이지 신청글 기록 
**GET /api/user/posts**
`getPostsWrittenByCurrentUser` 메서드에서 로그인 유저가 작성한 모든 게시물을 조회하여 반환합니다.

3. 마이페이지 신청완료 기록 
**GET /api/user/requests** 
명세에 없는 새로운 url 을 추가하여 매핑해 보았습니다.
`getPostsRequestedByCurrentUser` 메서드에서는 로그인 유저가 상대에게 친구 신청하여 `ACCEPTED`나 `PROGRESS` 상태인 게시물을 반환하도록 수정했습니다. 

4. 자기 자신에게 친구 신청하면 예외를 발생하는 로직을 추가했습니다.
